### PR TITLE
Fixed an issue with parametrized dependency fields generation

### DIFF
--- a/khoji-compiler/src/main/java/com/github/saadfarooq/khoji/KhojiCollection.java
+++ b/khoji-compiler/src/main/java/com/github/saadfarooq/khoji/KhojiCollection.java
@@ -2,18 +2,18 @@ package com.github.saadfarooq.khoji;
 
 import com.squareup.javapoet.*;
 
-import java.io.IOException;
-import java.util.*;
-
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+import java.io.IOException;
+import java.util.*;
 
 public class KhojiCollection {
-    private final Set<TypeMirror> mainDeps;
+    private final List<TypeMirror> mainDeps;
     private final Map<TypeElement, List<TypeMirror>> classDepsMap;
     private final TypeMirror iface;
     private final String genPkgName;
@@ -23,7 +23,7 @@ public class KhojiCollection {
 
     public KhojiCollection(TypeMirror iface, Elements elements, Types types) {
         this.types = types;
-        mainDeps = new LinkedHashSet<>();
+        mainDeps = new ArrayList<>();
         classDepsMap = new LinkedHashMap<>();
         this.iface = iface;
         this.genClassName = types.asElement(iface).getSimpleName() + "Collection";
@@ -31,7 +31,15 @@ public class KhojiCollection {
     }
 
     public void addMainDependency(TypeMirror typeMirror) {
-        mainDeps.add(typeMirror);
+        boolean exists = false;
+        for (TypeMirror type : mainDeps) {
+            if (types.isSameType(type, typeMirror)) {
+                exists = true;
+            }
+        }
+        if (!exists) {
+            mainDeps.add(typeMirror);
+        }
     }
 
     public void addClassDependencies(TypeElement clazz, List<TypeMirror> classDeps) {
@@ -39,30 +47,31 @@ public class KhojiCollection {
     }
 
     public void createFile(Filer filer) throws IOException {
-        TypeSpec.Builder magicDrawerItems = TypeSpec.classBuilder(genClassName).addModifiers(Modifier.PUBLIC);
+        TypeSpec.Builder magicItems = TypeSpec.classBuilder(genClassName).addModifiers(Modifier.PUBLIC);
         // Create constructor with main dependencies and field for each
         MethodSpec.Builder constructorBuilder = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
+        System.out.println("Main deps: " + mainDeps);
         for (TypeMirror dependency : mainDeps) {
-            String fieldName = types.asElement(dependency).getSimpleName().toString().toLowerCase();
+            String fieldName = getVariableName(dependency);
             constructorBuilder.addParameter(TypeName.get(dependency), fieldName);
             constructorBuilder.addStatement("this.$N = $N", fieldName, fieldName);
-            magicDrawerItems.addField(TypeName.get(dependency), fieldName, Modifier.PRIVATE, Modifier.FINAL);
+            magicItems.addField(TypeName.get(dependency), fieldName, Modifier.PRIVATE, Modifier.FINAL);
         }
 
         ParameterizedTypeName listOfInterface = ParameterizedTypeName.get(ClassName.get(List.class), TypeName.get(iface)); // List<Interface>
-        constructorBuilder.addStatement("this.$N = initDrawerItemsList()", "khojiItems");
-        magicDrawerItems.addField(listOfInterface, "khojiItems", Modifier.PRIVATE, Modifier.FINAL);
-        magicDrawerItems.addMethod(constructorBuilder.build());
+        constructorBuilder.addStatement("this.$N = initItems()", "khojiItems");
+        magicItems.addField(listOfInterface, "khojiItems", Modifier.PRIVATE, Modifier.FINAL);
+        magicItems.addMethod(constructorBuilder.build());
 
         MethodSpec.Builder khojiItemsMethodBuilder = MethodSpec.methodBuilder("getCollectedItems")
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .returns(listOfInterface);
         khojiItemsMethodBuilder.addStatement("return $N", "khojiItems");
 
-        magicDrawerItems.addMethod(khojiItemsMethodBuilder.build());
+        magicItems.addMethod(khojiItemsMethodBuilder.build());
 
 
-        MethodSpec.Builder initDrawerItemsList = MethodSpec.methodBuilder("initDrawerItemsList")
+        MethodSpec.Builder initDrawerItemsList = MethodSpec.methodBuilder("initItems")
                 .addModifiers(Modifier.PRIVATE)
                 .returns(listOfInterface)
                 .addStatement("$T result = new $T<>()", listOfInterface, ClassName.get(ArrayList.class));
@@ -70,7 +79,7 @@ public class KhojiCollection {
         for (Map.Entry<TypeElement, List<TypeMirror>> classEntry : classDepsMap.entrySet()) {
             StringBuilder statementFormat = new StringBuilder("result.add(new $T( ");
             for (TypeMirror dep : classEntry.getValue()) {
-                statementFormat.append(types.asElement(dep).getSimpleName().toString().toLowerCase());
+                statementFormat.append(getVariableName(dep));
                 statementFormat.append(",");
             }
             statementFormat.deleteCharAt(statementFormat.length() - 1)
@@ -79,11 +88,21 @@ public class KhojiCollection {
         }
 
         initDrawerItemsList.addStatement("return result");
-        magicDrawerItems.addMethod(initDrawerItemsList.build());
+        magicItems.addMethod(initDrawerItemsList.build());
 
-        JavaFile javaFile = JavaFile.builder(genPkgName, magicDrawerItems.build()).build();
+        JavaFile javaFile = JavaFile.builder(genPkgName, magicItems.build()).build();
         javaFile.writeTo(filer);
         fileWritten = true;
+    }
+
+    private String getVariableName(TypeMirror type) {
+        DeclaredType declaredType = (DeclaredType) type;
+        StringBuilder name = new StringBuilder();
+        name.append(declaredType.asElement().getSimpleName().toString().toLowerCase());
+        if (declaredType.getTypeArguments().size() > 0) {
+            name.append(types.asElement(declaredType.getTypeArguments().get(0)).getSimpleName().toString());
+        }
+        return name.toString();
     }
 
     public boolean isFileWritten() {

--- a/sample/src/chocolate/java/com/github/saadfarooq/sample/draweritem/ChocolateDrawerItem.java
+++ b/sample/src/chocolate/java/com/github/saadfarooq/sample/draweritem/ChocolateDrawerItem.java
@@ -4,9 +4,14 @@ import com.github.saadfarooq.khoji.KhojiTarget;
 
 @KhojiTarget
 public class ChocolateDrawerItem implements DrawerItem {
+    private final String name;
+
+    public ChocolateDrawerItem(String name) {
+        this.name = name;
+    }
 
     @Override
     public String getTitle() {
-        return "Chocolate";
+        return name;
     }
 }

--- a/sample/src/main/java/com/github/saadfarooq/sample/MainActivity.java
+++ b/sample/src/main/java/com/github/saadfarooq/sample/MainActivity.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 import com.github.saadfarooq.sample.draweritem.DrawerItem;
 import com.github.saadfarooq.sample.draweritem.DrawerItemCollection;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
@@ -27,7 +28,7 @@ public class MainActivity extends AppCompatActivity {
         drawerLayout.openDrawer(GravityCompat.START);
 
         ListView drawerList = (ListView) findViewById(R.id.drawer_list);
-        drawerList.setAdapter(new DrawerListAdapter(new DrawerItemCollection().getCollectedItems()));
+        drawerList.setAdapter(new DrawerListAdapter(new DrawerItemCollection("Main title", new ArrayList<String>()).getCollectedItems()));
     }
 
     private class DrawerListAdapter extends BaseAdapter {

--- a/sample/src/main/java/com/github/saadfarooq/sample/draweritem/MainDrawerItem.java
+++ b/sample/src/main/java/com/github/saadfarooq/sample/draweritem/MainDrawerItem.java
@@ -2,10 +2,18 @@ package com.github.saadfarooq.sample.draweritem;
 
 import com.github.saadfarooq.khoji.KhojiTarget;
 
+import java.util.List;
+
 @KhojiTarget
 public class MainDrawerItem implements DrawerItem {
+    private final String title;
+
+    public MainDrawerItem(String title, List<String> listString) {
+        this.title = title;
+    }
+
     @Override
     public String getTitle() {
-        return "I'm always here";
+        return title;
     }
 }

--- a/sample/src/vanilla/java/com/github/saadfarooq/sample/draweritem/VanillaDrawerItem.java
+++ b/sample/src/vanilla/java/com/github/saadfarooq/sample/draweritem/VanillaDrawerItem.java
@@ -2,11 +2,18 @@ package com.github.saadfarooq.sample.draweritem;
 
 import com.github.saadfarooq.khoji.KhojiTarget;
 
+import java.util.List;
+
 @KhojiTarget
 public class VanillaDrawerItem implements DrawerItem {
+    private final String title;
+
+    public VanillaDrawerItem(String title, List<String> list) {
+        this.title = title;
+    }
 
     @Override
     public String getTitle() {
-        return "Vanilla";
+        return title;
     }
 }


### PR DESCRIPTION
This makes it so that if @KhojiTarget annotated classes take `List<String>`, only one `listString` named field is created in the generated class and the instance is shared.

Future versions should include a way to provide extra information with dependencies (e.g. `@Qualifier` annotations) to decide whether to treat two types as same or different.